### PR TITLE
DL-368: root-cause CF Pages git integration outage

### DIFF
--- a/.agent/current-status.md
+++ b/.agent/current-status.md
@@ -1,8 +1,24 @@
 # Annual Reports CRM - Current Status
 
+**Last Updated:** 2026-04-28 (DL-368 — CF Pages git integration root-caused: stale `repo_id` in CF source binding; catch-up deploy of `21c1488` shipped; USER reconnect required)
 **Last Updated:** 2026-04-28 (Bright Data MCP registered via SSE — connected; server-name prefix is `brightdata`)
 **Last Updated:** 2026-04-28 (DL-366 — IMPLEMENTED, NEED TESTING; dashboard kebab adds two new actions: add/edit cc_email + auto-resend, and copy questionnaire link to clipboard)
 **Last Updated:** 2026-04-28 (DL-365 Phase 1 COMPLETE — smoke test passed, CF Logs verified, Logpush active; Phases 2-4 queued)
+
+## DL-368: CF Pages git integration broken — IMPLEMENTED (catch-up shipped) — USER ACTION required (2026-04-28)
+
+Pages project `annual-reports-client-portal` (`docs.moshe-atsits.com`) stopped auto-building from `main` pushes since 2026-04-27 evening. Root cause: CF Pages stored `source.config.repo_id=1136319991` is stale — actual GitHub repo id is `1222817442` (repo was deleted+recreated at some point). Every prod deploy on 2026-04-28 was manual `wrangler pages deploy` (`ad_hoc`, `commit_dirty=true`). All earlier "manual deploy: …" commit messages were workarounds for this. Design log: `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md`. Catch-up deploy of clean `origin/main` (HEAD `21c1488`) shipped via wrangler from a temp worktree → preview URL `https://4f7dbadf.annual-reports-client-portal.pages.dev`.
+
+### Test DL-368: verify CF Pages git integration restored
+
+- [ ] **USER ACTION:** Open CF Dash → Workers & Pages → `annual-reports-client-portal` → Settings → Builds & deployments → Git integration → "Manage GitHub App permissions" → ensure repo is in allowed list → Save → back on CF Pages, "Disconnect Git" then "Connect" and pick the same repo.
+- [ ] After reconnect, run from main: `git commit --allow-empty -m "chore(deploy): verify CF Pages git integration restored (DL-368)" && git push origin main`
+- [ ] Wait ~30s, then `cd api && npx wrangler pages deployment list --project-name=annual-reports-client-portal | head -5` — newest row should show new SHA, trigger `github:push` (NOT `ad_hoc`), `commit_dirty=false`.
+- [ ] Verify CF API: `curl -sS "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/annual-reports-client-portal" -H "Authorization: Bearer <token>" | jq '.result.source.config.repo_id'` → should equal `1222817442` (matches GitHub).
+- [ ] Browser cache-bust check on `https://docs.moshe-atsits.com` → admin/client surfaces serve current main.
+- [ ] Decide whether to add a periodic CF↔GitHub `repo_id` drift check (small `scripts/` script, optional CI gate). Out of DL-368; spin into a follow-up DL if approved.
+
+Design log: `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md`
 
 ## DL-365: Activity Logger — Phase 1 COMPLETE ✓ — Phases 2-4 TODO (2026-04-28)
 

--- a/.agent/design-logs/INDEX.md
+++ b/.agent/design-logs/INDEX.md
@@ -2,7 +2,7 @@
 
 Active and pending logs. For completed history, see [ARCHIVE-INDEX.md](ARCHIVE-INDEX.md).
 
-**Total logs:** 227 | **Active:** 129 | **Archived:** 98
+**Total logs:** 228 | **Active:** 130 | **Archived:** 98
 
 ## Folder Structure
 
@@ -12,7 +12,7 @@ Active and pending logs. For completed history, see [ARCHIVE-INDEX.md](ARCHIVE-I
 - `client-portal/` — Client Portal & Questionnaires (13)
 - `documents/` — Documents & OneDrive (20)
 - `email/` — Email System (21)
-- `infrastructure/` — Infrastructure & Workflows (20)
+- `infrastructure/` — Infrastructure & Workflows (21)
 - `reminders/` — Reminder System (17)
 - `research/` — Research & Feasibility (7)
 - `security/` — Security & Auth (7)
@@ -21,6 +21,7 @@ Active and pending logs. For completed history, see [ARCHIVE-INDEX.md](ARCHIVE-I
 
 | # | File | Status | Summary |
 |---|------|--------|---------|
+| 368 | [368-cf-pages-git-integration-broken.md](infrastructure/368-cf-pages-git-integration-broken.md) | IMPLEMENTED — NEED TESTING | CF Pages `annual-reports-client-portal` stopped firing builds from `main` pushes since 2026-04-27 evening. Root cause: stored `source.config.repo_id=1136319991` no longer matches GitHub's actual repo id `1222817442` — the GitHub repo was deleted and recreated at some point, orphaning CF's binding. GitHub PushEvents on main delivered fine; CF just ignored them. All 10 prod deploys today were `ad_hoc` from manual `wrangler pages deploy` with `commit_dirty=true`. Fix: (1) catch-up deploy of clean main HEAD `21c1488` shipped via wrangler from a temporary worktree; (2) USER must reconnect Git integration in CF Dash → Pages → Settings → Git integration (no public API for repo rebinding); (3) verification via empty trigger commit + checking next deploy has `trigger.type=github:push` and CF `repo_id=1222817442`. Suggests follow-up: nightly drift check comparing CF `repo_id` vs GitHub `id`. |
 | 367 | [367-gmail-drive-smart-links.md](email/367-gmail-drive-smart-links.md) | IMPLEMENTED — NEED TESTING | Inbound pipeline now fetches Gmail "Insert from Drive" smart-link attachments (live case: CPA-XXX, 4 PDFs lost 2026-04-28). Gmail embeds them as inline `gmail_drive_chip` HTML cards with `hasAttachments=false`, so `fetchAttachments` returned 0 and the email completed silently. New `parseDriveLinks(bodyHtml)` extracts `{fileId, filename}` from chip divs (matched by `class*=gmail_drive_chip` + `id="<fileId>"`, with `title="..."` on inner `<div>`) and bare `drive.google.com/file/d/...` URLs; `fetchDriveAttachment(link, maxBytes=25MB)` calls `https://drive.usercontent.google.com/download?id={id}&export=download&authuser=0&confirm=t` (post-May-2024 endpoint), validates Content-Type (rejects HTML "you need access" page), streams with byte cap, computes sha256, synthesizes the same `AttachmentInfo` shape as Graph attachments — pipeline downstream is unchanged. New `stripDriveChipsFromHtml` removes chip divs in `extractMetadata` before HTML→text so chip filenames don't pollute the LLM-summarized note. `ghostAttachments` guard extended to also fire when Drive links found but all fetches failed. Per-file failure → email_event `NeedsHuman` with Drive URLs preserved in `error_message`. Backfill confirmed: 4 pending_classifications with proper Hebrew names + 3 T501 matches at conf 0.95. Files: `attachment-utils.ts`, `processor.ts`. |
 | 366 | [366-kebab-add-cc-email-and-resend.md](admin-ui/366-kebab-add-cc-email-and-resend.md) | IMPLEMENTED — NEED TESTING | Two new dashboard kebab actions: (1) "הוסף/ערוך אימייל משני" opens `ClientDetailModal` auto-focused on `cc_email` (new `focusField` prop threaded through bridge → island → component); on save when stage=`Send_Questionnaire`, prompts `showConfirmDialog` to re-send via existing `sendSingle(rid)`; off stage 1, toast only. (2) "העתק קישור לשאלון" (stages 1–3) calls new Worker route `POST /webhook/admin-questionnaire-link` which mints a fresh signed URL via new helper `api/src/lib/questionnaire-url.ts` (extracted from `send-questionnaires.ts:81`); frontend writes URL to clipboard. Dashboard API (`dashboard.ts`) now returns `cc_email` per row via parallel clients-table fetch + Map join. Cache-bust `script.js?v=369→370` (rebased over DL-364). Out of scope: extending CC to non-questionnaire emails (deferred). |
 | 365 | [365-activity-logger.md](infrastructure/365-activity-logger.md) | BEING IMPLEMENTED — DL-365 (Phase 1 COMPLETE — smoke test passed 2026-04-28) | Replace Airtable security_logs with Cloudflare-native activity logger (Workers Logs + R2). Phase 1 (Foundation) shipped + verified live. PII strategy: client_id-only logs + viewer-side Airtable join. Phases 2-4 queued. |

--- a/.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md
+++ b/.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md
@@ -1,0 +1,125 @@
+# Design Log 368: Cloudflare Pages Git Integration Stopped Firing Builds
+**Status:** [BEING IMPLEMENTED — DL-368]
+**Date:** 2026-04-28
+**Related Logs:** None — first incident of this kind
+
+## 1. Context & Problem
+
+Cloudflare Pages project `annual-reports-client-portal` (serves `docs.moshe-atsits.com`) stopped auto-building from GitHub `main` pushes some time on 2026-04-27. Frontend changes pushed to main were not appearing on the live site without somebody manually running `wrangler pages deploy`. The user noticed because frontend changes from the last ~4 commits were not reflected in the browser.
+
+## 2. User Requirements
+
+1. **Q:** Which Cloudflare Pages project is affected?
+   **A:** `annual-reports-client-portal` (`docs.moshe-atsits.com`).
+2. **Q:** How was the symptom noticed?
+   **A:** Frontend changes not live in browser despite pushes to main.
+3. **Q:** Action scope?
+   **A:** Diagnose + fix automatically (recommended).
+4. **Q:** One-shot redeploy of missed commits?
+   **A:** Yes — trigger a deploy of current main after fixing.
+
+## 3. Research
+
+### Domain
+Cloudflare Pages git integration (GitHub App webhook delivery + repo binding).
+
+### Sources Consulted
+Skipped formal Tier-1/2/3 research — this is a CF/GitHub ops diagnostic where the answer comes from inspecting the live API state, not from books or articles. Operational evidence below replaces literature review.
+
+### Key Principles Extracted
+- **Verify both ends of an integration.** GitHub knew about the pushes; CF didn't. Checking only one side would have missed the broken binding.
+- **Trust deployment metadata.** `deployment_trigger.type` and `commit_dirty` revealed that every recent prod deploy was a manual `wrangler pages deploy` from a dirty tree, not a push-driven build.
+- **A repo's GitHub `id` is the stable join key, not its name.** Names get reused; IDs do not. Mismatched IDs are the canonical sign of "repo deleted and recreated".
+
+### Patterns to Use
+- For any future "integration silently stopped" report: pull `deployment_trigger.type` from CF, then compare CF `source.config.repo_id` against `gh api repos/{owner}/{repo} --jq .id`.
+
+### Anti-Patterns to Avoid
+- "Just click Reconnect and hope" — without first confirming the repo-ID mismatch, we wouldn't have known whether the reconnect was a real fix or a placebo.
+
+### Research Verdict
+Diagnose via CF + GitHub APIs (done), then fix via dashboard reconnect (only path — no public API for repo rebinding).
+
+## 4. Codebase Analysis
+
+* **Existing Solutions Found:** None — no existing automation for CF Pages integration health checks. `api/` has `wrangler.toml` for the Worker but Pages config is dashboard-managed.
+* **Reuse Decision:** Nothing to reuse; this is a one-off ops fix, not a codebase change.
+* **Relevant Files:** None changed. Project build config from CF API:
+  - `build_command: ""`
+  - `root_dir: ""`
+  - `destination_dir: "frontend"`
+  - → Pages uploads `frontend/` directly with no build step.
+* **Existing Patterns:** Project history shows manual `wrangler pages deploy` has been a recurring fallback (see commit messages "manual deploy: ..."). That pattern masked the integration outage for ~18 hours.
+* **Alignment with Research:** N/A
+* **Dependencies:**
+  - GitHub App: "Cloudflare Pages" installed on `LiozShor` GitHub account
+  - CF Pages project source binding (`source.config` in project record)
+
+## 5. Technical Constraints & Risks
+
+* **Security:** Reconnect requires the user's CF + GitHub App owner permissions. No new secrets.
+* **Risks:**
+  - The reconnect flow may briefly disconnect git integration entirely. Acceptable — manual `wrangler pages deploy` still works as fallback during the gap.
+  - If the GitHub App was actually uninstalled (not just out of sync), reconnect requires reinstalling.
+* **Breaking Changes:** None.
+
+## 6. Proposed Solution (The Blueprint)
+
+### Success Criteria
+A push to `main` produces a CF Pages deployment where `deployment_trigger.type == "github:push"` (not `"ad_hoc"`) and `commit_dirty == false`, and `source.config.repo_id` matches GitHub's current repo ID `1222817442`.
+
+### Logic Flow
+
+**Step 1 (automated, this session) — Catch-up deploy:**
+1. `git fetch origin main`
+2. `git worktree add ../tmp-deploy-main origin/main` (clean checkout)
+3. `npx wrangler pages deploy frontend --project-name=annual-reports-client-portal --branch=main --commit-hash=$(git rev-parse HEAD) --commit-message="<HEAD msg> (manual catch-up — DL-368)"`
+4. `git worktree remove ../tmp-deploy-main`
+
+**Step 2 (manual, user does in browser):**
+1. CF Dash → Workers & Pages → `annual-reports-client-portal` → Settings → Builds & deployments → Git integration → Manage GitHub App permissions
+2. On GitHub Cloudflare Pages app: confirm `LiozShor/annual-reports-client-portal` is in allowed repos; Save.
+3. CF Dash → Disconnect Git → Reconnect → select same repo → Save.
+
+**Step 3 (verification, this or next session):**
+1. `git commit --allow-empty -m "chore(deploy): verify CF Pages git integration restored (DL-368)" && git push origin main`
+2. ~30s later, `wrangler pages deployment list` newest row should show `Source = <new-sha>`, trigger `github:push`, dirty `false`.
+3. `curl .../pages/projects/annual-reports-client-portal | jq .result.source.config.repo_id` → expect `1222817442`.
+
+### Data Structures / Schema Changes
+None.
+
+### Files to Change
+
+| File | Action | Description |
+|---|---|---|
+| `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md` | Create | This file |
+| `.agent/design-logs/INDEX.md` | Modify | Add DL-368 row |
+| `.agent/current-status.md` | Modify | Add DL-368 test entry under Active TODOs (Step 2 user action + Step 3 verification) |
+
+### Final Step (Always)
+Mark log `[IMPLEMENTED — NEED TESTING]`, copy unchecked Section 7 items into `current-status.md`.
+
+## 7. Validation Plan
+
+- [ ] Catch-up deploy succeeds → `wrangler pages deployment list` shows fresh prod deploy with current `main` HEAD SHA
+- [ ] `docs.moshe-atsits.com` serves expected current-main content (cache-bust check in browser)
+- [ ] **USER ACTION:** Complete CF Dashboard reconnect (Step 2)
+- [ ] Test push to main triggers `github:push` deploy (not `ad_hoc`) — visible in `wrangler pages deployment list`
+- [ ] CF API `source.config.repo_id` == `1222817442` after reconnect
+- [ ] Decide whether to add a periodic integrity check (e.g. nightly script comparing CF `repo_id` vs GitHub repo `id`) — defer to follow-up DL if approved
+
+## 8. Implementation Notes (Post-Code)
+
+### Evidence captured during diagnosis (2026-04-28T12:14Z)
+
+- GitHub `repos/LiozShor/annual-reports-client-portal` → `id`: **1222817442** (current)
+- CF Pages `source.config.repo_id`: **1136319991** (stale, points to a no-longer-existent repo record)
+- GitHub `repos/.../events` → 5 PushEvents on `main` between 11:43:39Z and 12:10:37Z, all delivered.
+- CF Pages last `github:push` deploy to **production**: 2026-04-27T18:24:31Z (commit `5bc63b16`).
+- Every prod deploy on 2026-04-28 (10 deploys) had `deployment_trigger.type=ad_hoc` and `commit_dirty=true` → all manual `wrangler pages deploy` from local checkouts.
+- CF project flags: `production_deployments_enabled: true`, `deployments_enabled: true`, `path_includes:["*"]`, `path_excludes:[]`. So the cause is NOT pause/path-filter.
+
+### Note for future
+- The repo was at some point deleted+recreated (or transferred and restored) on GitHub, which orphaned CF's binding. We don't have a record of when/why; suggest checking older sessions (`.agent/design-logs/INDEX.md` around 2026-04-27 evening) if recurrence investigation is ever needed.
+- Consider a guard: a small script (could live in `scripts/`) that does `gh api repos/LiozShor/annual-reports-client-portal --jq .id` vs CF `source.config.repo_id` comparison and fails CI if they drift. Out of scope for DL-368.


### PR DESCRIPTION
## Summary

- Root-cause investigation of CF Pages `annual-reports-client-portal` no longer firing builds from `main` pushes since 2026-04-27 evening.
- Cause: stored `source.config.repo_id=1136319991` is stale — actual GitHub repo id is `1222817442` (repo deleted+recreated at some point), so CF drops inbound push webhooks.
- Catch-up deploy of clean `origin/main` HEAD `21c1488` already shipped via `wrangler pages deploy`. This PR adds the design log + status entry; the merge commit itself doubles as the live test for whether GitHub-App reinstall restored the integration.

Design log: `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md`

## Test plan

- [ ] Merging this PR triggers a deploy with `deployment_trigger.type = github:push` (NOT `ad_hoc`).
- [ ] CF API `source.config.repo_id` updates to `1222817442`.
- [ ] CF Pages "internal issue" banner clears.

User pre-approved merge to main for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)