### PR TITLE
DL-368: update status — CF support ticket required

### DIFF
--- a/.agent/current-status.md
+++ b/.agent/current-status.md
@@ -1,22 +1,28 @@
 # Annual Reports CRM - Current Status
 
-**Last Updated:** 2026-04-28 (DL-368 — CF Pages git integration root-caused: stale `repo_id` in CF source binding; catch-up deploy of `21c1488` shipped; USER reconnect required)
+**Last Updated:** 2026-04-28 (DL-368 — GitHub App reinstall did NOT fix it; `source.config.repo_id` still stale; CF support ticket required to rebind project to new repo id)
 **Last Updated:** 2026-04-28 (Bright Data MCP registered via SSE — connected; server-name prefix is `brightdata`)
 **Last Updated:** 2026-04-28 (DL-366 — IMPLEMENTED, NEED TESTING; dashboard kebab adds two new actions: add/edit cc_email + auto-resend, and copy questionnaire link to clipboard)
 **Last Updated:** 2026-04-28 (DL-365 Phase 1 COMPLETE — smoke test passed, CF Logs verified, Logpush active; Phases 2-4 queued)
 
-## DL-368: CF Pages git integration broken — IMPLEMENTED (catch-up shipped) — USER ACTION required (2026-04-28)
+## DL-368: CF Pages git integration broken — NEEDS CF SUPPORT TICKET (2026-04-28)
 
-Pages project `annual-reports-client-portal` (`docs.moshe-atsits.com`) stopped auto-building from `main` pushes since 2026-04-27 evening. Root cause: CF Pages stored `source.config.repo_id=1136319991` is stale — actual GitHub repo id is `1222817442` (repo was deleted+recreated at some point). Every prod deploy on 2026-04-28 was manual `wrangler pages deploy` (`ad_hoc`, `commit_dirty=true`). All earlier "manual deploy: …" commit messages were workarounds for this. Design log: `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md`. Catch-up deploy of clean `origin/main` (HEAD `21c1488`) shipped via wrangler from a temp worktree → preview URL `https://4f7dbadf.annual-reports-client-portal.pages.dev`.
+Pages project `annual-reports-client-portal` (`docs.moshe-atsits.com`) stopped auto-building from `main` pushes since 2026-04-27 evening. Root cause: CF Pages stored `source.config.repo_id=1136319991` is stale — actual GitHub repo id is `1222817442` (repo was deleted+recreated). GitHub App was reinstalled + merge commit `cee8e32` pushed to main — CF still didn't fire a build; no check-run on the commit; `repo_id` unchanged. Manual `wrangler pages deploy` from clean main worktree is the workaround for now.
 
-### Test DL-368: verify CF Pages git integration restored
+**Workaround (run after every frontend push to main until fixed):**
+```
+cd C:/Users/liozm/Desktop/moshe/annual-reports
+git pull --ff-only origin main
+npx wrangler pages deploy frontend --project-name=annual-reports-client-portal --branch=main \
+  --commit-hash=$(git rev-parse HEAD) --commit-message="$(git log -1 --pretty=%s) (manual)"
+```
 
-- [ ] **USER ACTION:** Open CF Dash → Workers & Pages → `annual-reports-client-portal` → Settings → Builds & deployments → Git integration → "Manage GitHub App permissions" → ensure repo is in allowed list → Save → back on CF Pages, "Disconnect Git" then "Connect" and pick the same repo.
-- [ ] After reconnect, run from main: `git commit --allow-empty -m "chore(deploy): verify CF Pages git integration restored (DL-368)" && git push origin main`
-- [ ] Wait ~30s, then `cd api && npx wrangler pages deployment list --project-name=annual-reports-client-portal | head -5` — newest row should show new SHA, trigger `github:push` (NOT `ad_hoc`), `commit_dirty=false`.
-- [ ] Verify CF API: `curl -sS "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/annual-reports-client-portal" -H "Authorization: Bearer <token>" | jq '.result.source.config.repo_id'` → should equal `1222817442` (matches GitHub).
-- [ ] Browser cache-bust check on `https://docs.moshe-atsits.com` → admin/client surfaces serve current main.
-- [ ] Decide whether to add a periodic CF↔GitHub `repo_id` drift check (small `scripts/` script, optional CI gate). Out of DL-368; spin into a follow-up DL if approved.
+### OPEN BLOCKER: CF support ticket required
+
+- [ ] **USER ACTION — Open CF support ticket:** CF Dash → Pages → Settings → blue "internal issue" banner → "please contact support". Paste:
+  > Pages project `annual-reports-client-portal` (account `ae0f0a190f9375f27d6043111996b1ef`) has stale `source.config.repo_id = 1136319991`. Actual GitHub repo `LiozShor/annual-reports-client-portal` has id `1222817442` — repo was deleted and recreated. GitHub App is installed. Pushes to `main` produce no `github:push` deploys (e.g. merge commit `cee8e32f886860dd6626a07712ae0f922c1d3937` at 2026-04-28T12:38Z, no Pages build, no check-run). Please rebind the project to repo id `1222817442`.
+- [ ] After CF support fixes it: verify next push to `main` shows `deployment_trigger.type=github:push` (not `ad_hoc`) in `wrangler pages deployment list`.
+- [ ] CF API `source.config.repo_id` == `1222817442` after fix.
 
 Design log: `.agent/design-logs/infrastructure/368-cf-pages-git-integration-broken.md`
 


### PR DESCRIPTION
Updates current-status.md: GitHub App reinstall did NOT fix the CF Pages git integration. source.config.repo_id still stale. Adds CF support ticket template + manual deploy workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)