### PR TITLE
feat(hooks): section-aware pruner for current-status.md

### DIFF
--- a/.agent/current-status.md
+++ b/.agent/current-status.md
@@ -27,6 +27,9 @@
 
 ---
 
+**Last Updated:** 2026-05-05 (DL-404 — IMPLEMENTED, NEED TESTING. One-click merge of two clients into a single household. Worker deployed, dashboard hotfix landed.)
+
+
 ## OPEN: DL-404 — Merge two clients into one
 
 DL: `.agent/design-logs/admin-ui/404-merge-clients.md`
@@ -61,7 +64,6 @@ Open-test items from Section 7:
 - Deletion of the empty loser OneDrive folder (audit-preserve).
 - **n8n reminder workflow CC** (DL-405 candidate) — Worker `reminders.ts` delegates to the n8n `/send-reminder-manual` workflow which needs its own CC wiring; out of scope for DL-404.
 
-
 ## OPEN: DL-401 — Unidentified inbound doc rows clickable
 
 DL: `.agent/design-logs/ai-review/401-unidentified-doc-row-clickable.md`
@@ -76,25 +78,12 @@ Open-test items from Section 7 (frontend-only; Pages auto-deploys on push):
 - [ ] Mobile (narrow viewport) — row click triggers `loadDocPreview` via DL-334 mobile short-circuit.
 - [ ] Hard-refresh — confirm `script.js?v=414` is served.
 
-## OPEN: DL-400 — Edit-client modal row disappears on save
-
-DL: `.agent/design-logs/admin-ui/400-edit-client-modal-row-disappears-on-save.md`
-
-Open-test items from Section 7 (frontend-only; Pages auto-deploys on push):
-
-- [ ] Edit only `phone` on a real client → row stays visible, name/email/cc_email unchanged.
-- [ ] Edit only `name` → row stays visible, other fields preserved.
-- [ ] Edit only `email` → row stays visible, other fields preserved.
-- [ ] Edit only `cc_email` → row stays visible, other fields preserved.
-- [ ] Edit two fields at once → both update, row visible.
-- [ ] Active search term during save → row remains in filtered view if still matches.
-- [ ] Hard reload after save → values match Airtable (server write succeeded).
-- [ ] Cancel button → no change to local state.
-- [ ] Hard-refresh → confirm `script.js?v=407` is served.
+## SHIPPED: DL-400 — Edit-client modal row disappears on save (closed 2026-05-03)
 
 ## Recent (last 7 days)
 
 - **2026-05-03 · DL-398 — COMPLETED.** Admin dashboard stat cards show small muted percentage next to count for stages 1–8 (% of `counts.total` active clients, whole numbers, parenthesized superscript). Total card unchanged. JS-only injection inside `recalculateStats()` — single render path. Cache-bust script.js v=403→405, style.css v=384→386 (initial render glued count to percent — fixed in followup commit `d082b1f7` with parens + 0.45em font + vertical-align 0.35em). User confirmed live. DL: `.agent/design-logs/admin-ui/398-stat-card-percentage.md`.
+
 ## Recent (last 7 days)
 
 - **2026-05-03 · DL-399 COMPLETED.** Email bounce / NDR handling shipped + live-verified end-to-end. Worker version `40392bcc-7d21-45e0-9abc-1c92f01c67c6`. New `bounce-detector.ts` parses Outlook NDRs (Hebrew + EN subject prefixes, body recipient extraction with office+sender domain exclusion) before the auto-reply short-circuit; `bounce-handler.ts` clears the matched client's email, writes 4 audit fields, reverts Stage-2 reports to Stage-1, logs to activity-logger. Frontend (extracted to `modules/bounce-warning.js` due to monolith size ratchet): clickable warning button next to the stage badge (desktop + mobile) opens a bounce-detail modal; pin bounced clients to top of table; Stage-1 stat-card pulses blue (distinct from Stage-3 amber); paper-plane row button + bulk-send gated on non-empty email; post-edit-save confirm in Stage-1. Schema: 4 new fields on the clients table, `Bounced` option on `email_events.processing_status`. Mid-flight fixes folded in: regex anchors broken by Hebrew NDR subject prefix → word-boundaries; sender-NDR-robot fallback defaults to isHard true; recipient-extraction fallback excludes office + sender domains; admin-dashboard route extended to expose the 4 bounce fields per client; bounce-modal lookup switched from `window.clientsData` (was let-scoped, undefined inside the module) to button data-* attrs; nav count badges enlarged 11px → 14px. DL: `.agent/design-logs/admin-ui/399-email-bounce-handling.md`.
@@ -106,19 +95,7 @@ Open-test items from Section 7 (frontend-only; Pages auto-deploys on push):
 
 User wants: removing the "מסמך זה כבר קיים ברשימה" guard from add-doc popover so admin can deliberately create N instances of the same template (rental property #1, #2, …; multiple invoices from different issuers). Touch points: `_paAddDocConfirm` / `addAIDoc` in `frontend/admin/js/script.js`; UX decision (warn-and-confirm vs. just allow).
 
-## OPEN: DL-395 — PA review yes-answers visibility
-
-DL: `.agent/design-logs/admin-ui/395-pa-review-show-yes-answers.md`
-
-Open-test items from Section 7 (deploy Pages first, then verify on live admin):
-
-- [ ] PA review for a sample client — confirm questionnaire-answers section lists has-children=✓, business-stock=✓, pension/keren-hishtalmut/life-insurance rows (with company values), no yes/free subsection split.
-- [ ] Click print button on the same card — printed sheet matches the on-screen list 1:1.
-- [ ] `[H:no]` toggle regression — pick a client with ≥1 `✗ [H:no]`; confirm count, expand/collapse work, no row leaks to main list.
-- [ ] Empty `answers_all` client — section renders nothing.
-- [ ] DL-302 cross-highlight — hover a yes-answer with `template_ids`; related doc tags highlight. Yes-answer with no templates — no error.
-- [ ] Mobile <1024px — single column, no horizontal overflow.
-- [ ] Hard-refresh — confirm `script.js?v=400` is served.
+## SHIPPED: DL-395 — PA review yes-answers visibility (closed 2026-05-02)
 
 ## Recent (last 7 days)
 
@@ -128,12 +105,13 @@ Open-test items from Section 7 (deploy Pages first, then verify on live admin):
 - **2026-05-02 · DL-391 cascade-revert 422 fix — COMPLETED.** `notification_status: null` instead of `''` (commit 94964040). Verified on main.
 - **Pages cache-bust race resolved.** Pages git auto-deploy is back online (verified 2026-05-02). Manual `wrangler pages deploy` races against the git build and 502s on `/pages/assets/upload`. Memory: `reference_pages_git_autodeploy_back.md`. DL-368 marked archival once user confirms the auto-deploy is stable across multiple commits.
 
-
-
 **Last Updated:** 2026-05-01 (DL-391 — IMPLEMENTED, NEED TESTING; DL-386 follow-up. Chip menu in AI review [required-docs] now offers "📎 שייך את התצוגה הפעילה למסמך זה" as the first option when (a) `aiActionsPanel.dataset.itemId` is set, (b) chip status is `Required_Missing`, (c) chip's `doc_record_id` differs from the active item's `matched_doc_record_id`. One-click — calls existing `submitAIReassign(activeItemId, templateId, docRecordId)` (script.js:7773); same path DL-386's inline prompt uses (line 11523). `renderDocTag` adds `data-template-id` to chip span. New `selectDocTagAssignToCard` handler next to `selectDocTagStatus`. No CSS / Worker / schema changes. Cache-bust `script.js?v=394→395`. **Verify:** (a) chip menu without active card → option NOT visible; (b) open a pending card preview, then click an unrelated `Required_Missing` chip → option appears as **first** item with paperclip icon, divider below it, status options + Edit name follow; (c) click → toast → success → card auto-advances; (d) `Received` / `Waived` / `Requires_Fix` chips → option NOT visible; (e) general_doc + spouse-doc chips both work; (f) PA tab unaffected (separate `openPaDocTagMenu`); (g) DevTools shows `script.js?v=395`. DL-391 at `.agent/design-logs/ai-review/390-chip-menu-assign-to-this-doc.md`. Pages deploy needed before testing.)
 
+
 **Last Updated:** 2026-05-01 (DL-386 — COMPLETED; "+ [H:add-doc]" chip in AI review [H:required-docs] section, AI-aware PA add-doc popover, silent refresh, spouse selector, and inline assign prompt anchored to the freshly-added chip. Worker exposes `spouse_name` per classification. Verified live on CPA-XXX test client (with dummy spouse). DL-386 at `.agent/design-logs/ai-review/386-add-required-doc-from-ai-review.md`. **TODO (deferred follow-up):** when admin is on a pending card and clicks an existing chip in [H:required-docs], the chip's `openDocTagMenu` should also offer "[H:assign-to-this-doc]" as the first menu item (current options: "[H:hebrew]"=Received, "[H:hebrew]"=Waived, "[H:hebrew]"=edit name) — invokes `submitAIReassign(activeCardId, chip.template_id, chip.doc_record_id)`. Same affordance as the inline prompt after add, but reachable from any existing chip while a card is open in the cockpit. Touch points: `openDocTagMenu` (script.js ~line 9120), `selectDocTagStatus` handler. Gate the new option on `aiActionsPanel[data-item-id]` being set.)
+
 **Last Updated:** 2026-05-01 — DL-368, DL-376, DL-384, DL-387, DL-388 marked done.
+
 
 ## Recent (last 7 days)
 
@@ -150,6 +128,7 @@ Open-test items from Section 7 (deploy Pages first, then verify on live admin):
 
 ---
 
+
 ## OPEN: DL-365 — Activity Logger Phases 3-5
 
 DL: `.agent/design-logs/infrastructure/365-activity-logger.md`
@@ -162,11 +141,13 @@ Still need Worker secrets: `DEV_PASSWORD`, `PII_HASH_KEY` (`wrangler secret put`
 
 ---
 
+
 ## OPEN: W02 regression — wrangler deploy script missing `-c wrangler.toml`
 
 `api/package.json` deploy script needs `-c wrangler.toml` flag so `check-regressions.sh` W02 case passes honestly.
 
 ---
+
 
 ## 2026-05-03 — Security deep audit run
 

--- a/.claude/hooks/prune-current-status.py
+++ b/.claude/hooks/prune-current-status.py
@@ -1,26 +1,97 @@
 #!/usr/bin/env python3
-"""Prune .agent/current-status.md when "Last Updated" history grows too long.
+"""Prune .agent/current-status.md on SessionStart.
 
-Runs on SessionStart. Idempotent; silent when nothing to do.
+Replaces the older "split at first ---" pruner. That version only counted
+**Last Updated:** lines and never archived OPEN sections, so closed DLs
+accumulated forever.
 
 Behavior:
-- Splits the file at the first standalone `---` separator.
-- HEADER = title + chronological "**Last Updated:**" lines (one per line, in file order).
-- BODY  = everything from `---` onward (OPEN/SHIPPED state sections — preserved verbatim).
-- Keeps the newest KEEP entries in HEADER. Older entries are prepended (newest-first)
-  to .agent/current-status-archive.md under a dated section.
-- Triggers only when entry count > THRESHOLD.
+  1. Parse current-status.md as a typed grammar (TITLE / LOG / OPEN / SHIPPED /
+     NEXT / RECENT / DATED / SEP). Unknown section -> bail loudly, no writes.
+  2. For every "## OPEN: DL-NNN ..." section, look up DL-NNN in
+     .agent/design-logs/INDEX.md. If status starts with COMPLETED, demote the
+     whole section to a one-line "## SHIPPED: DL-NNN -- title (closed DATE)".
+  3. Drop bullets in "## Recent (last 7 days)" older than 7 days.
+  4. Trim the chronological **Last Updated:** log to newest 5 (threshold 8).
+  5. If active file still > 250 lines, archive SHIPPED rows + ## YYYY-MM-DD
+     blocks older than 14 days to .agent/current-status-archive.md.
+  6. Append a one-line breadcrumb at the bottom pointing to the archive.
+
+Safety:
+  - Default first 2 runs are dry-run (writes a counter at .claude/state/
+    prune-runs.json). After that, automatic.
+  - --dry-run flag forces preview-only.
+  - Atomic rewrite via tempfile + os.replace. Lock at .agent/.prune.lock
+    (skip silently if held <60s ago).
+  - Bail-and-warn: any unknown section header, unparseable INDEX row, or
+    parser error => stderr message, exit 0, no writes.
+
+PII guard note: agent-pii-guard.py's --all mode is informational-only
+(exits 0 unconditionally per its docstring). The pruner only rearranges
+content that was already in the file -- it cannot introduce new PII -- so
+no inline guard call is made here. The existing pre-commit hook covers the
+file at commit time.
 """
 from __future__ import annotations
+
 import datetime as _dt
+import json
+import os
 import re
 import sys
+import tempfile
+import time
 from pathlib import Path
 
-THRESHOLD = 15   # prune when more than this many entries
-KEEP = 10        # keep this many newest entries after pruning
+# ---- Tunables -----------------------------------------------------------
 
-ENTRY_RE = re.compile(r"^\*\*Last Updated:\*\*", re.MULTILINE)
+LINE_CAP = 250                # archive triggers above this many lines
+LOG_THRESHOLD = 8             # prune the **Last Updated:** log above this
+LOG_KEEP = 5                  # newest N entries to keep
+RECENT_WINDOW_DAYS = 7        # for "## Recent (last 7 days)" bullets
+ARCHIVE_AGE_DAYS = 14         # archive SHIPPED + dated blocks older than this
+DRY_RUN_FIRST_N = 2           # first N runs are forced dry-run
+LOCK_TTL_SECONDS = 60
+
+COMPLETED_STATUS_PREFIXES = ("COMPLETED",)  # add BLOCKED/WONTFIX here later
+KEEP_OPEN_STATUS_PREFIXES = (
+    "IMPLEMENTED",
+    "DRAFT",
+    "BEING IMPLEMENTED",
+    "PENDING",
+    "BLOCKED",
+)
+
+# ---- Section grammar ----------------------------------------------------
+
+# Recognized line markers. Anything else => unknown => bail.
+RE_TITLE = re.compile(r"^# Annual Reports CRM")
+RE_LOG = re.compile(r"^\*\*Last Updated:\*\*\s*(\d{4}-\d{2}-\d{2})")
+RE_OPEN_DL = re.compile(r"^## OPEN:\s*DL-(\d+)\s*[—-]\s*(.+)$")
+RE_OPEN_OTHER = re.compile(r"^## OPEN:\s*(?!DL-\d)(.+)$")
+RE_SHIPPED = re.compile(
+    r"^## SHIPPED:\s*DL-(\d+)\s*[—-]\s*(.+?)\s*\(closed (\d{4}-\d{2}-\d{2})\)\s*$"
+)
+RE_NEXT = re.compile(r"^## NEXT[ :(]")
+RE_RECENT = re.compile(r"^## Recent \(last 7 days\)\s*$")
+RE_DATED = re.compile(r"^## (\d{4}-\d{2}-\d{2})\s*[—-]\s*(.+)$")
+RE_SEP = re.compile(r"^---\s*$")
+RE_H2 = re.compile(r"^## ")
+RE_BREADCRUMB = re.compile(r"^>\s*Older entries archived")
+
+# Recent-bullet leading date: "- **YYYY-MM-DD ..."
+RE_RECENT_BULLET_DATE = re.compile(r"^[-*]\s+\*\*(\d{4}-\d{2}-\d{2})")
+
+# INDEX.md row: "| 405 | [...](path) | STATUS string | summary |"
+RE_INDEX_ROW = re.compile(r"^\|\s*(\d+)\s*\|")
+# COMPLETED date capture: "COMPLETED — 2026-05-03" or "COMPLETED -- 2026-05-03"
+RE_COMPLETED_DATE = re.compile(r"COMPLETED\s*[—-]+\s*(\d{4}-\d{2}-\d{2})")
+
+
+# ---- IO helpers ---------------------------------------------------------
+
+def warn(msg: str) -> None:
+    sys.stderr.write(f"[prune-current-status] {msg}\n")
 
 
 def find_repo_root(start: Path) -> Path | None:
@@ -30,71 +101,484 @@ def find_repo_root(start: Path) -> Path | None:
     return None
 
 
-def main() -> int:
+def load_index(index_path: Path) -> dict[int, str]:
+    """Return {dl_num: status_string} parsed from INDEX.md pipe-table rows."""
+    if not index_path.exists():
+        return {}
+    out: dict[int, str] = {}
+    for raw in index_path.read_text(encoding="utf-8").splitlines():
+        m = RE_INDEX_ROW.match(raw)
+        if not m:
+            continue
+        cols = [c.strip() for c in raw.split("|")]
+        # cols[0] is empty (leading "|"). Indices: 1=NNN, 2=link, 3=status, 4=summary
+        if len(cols) < 5:
+            continue
+        try:
+            dl_num = int(cols[1])
+        except ValueError:
+            continue
+        out[dl_num] = cols[3]
+    return out
+
+
+# ---- Parser -------------------------------------------------------------
+
+class Section:
+    __slots__ = ("kind", "header", "lines", "dl_num", "date", "title")
+
+    def __init__(self, kind: str, header: str = ""):
+        self.kind = kind          # "title", "log", "open_dl", "open_other",
+                                  # "shipped", "next", "recent", "dated",
+                                  # "sep", "breadcrumb", "preface"
+        self.header = header
+        self.lines: list[str] = []
+        self.dl_num: int | None = None
+        self.date: _dt.date | None = None
+        self.title: str = ""
+
+
+def parse(text: str) -> tuple[list[Section], list[str]]:
+    """Parse text into typed sections. Returns (sections, errors).
+
+    On any unknown structure, errors is non-empty and caller must bail.
+    """
+    sections: list[Section] = []
+    errors: list[str] = []
+
+    lines = text.splitlines()
+    cur: Section | None = None
+
+    def flush():
+        nonlocal cur
+        if cur is not None:
+            sections.append(cur)
+            cur = None
+
+    # First pass: classify each line; H2 boundaries start new sections.
+    for i, ln in enumerate(lines, start=1):
+        stripped = ln.rstrip()
+
+        if RE_TITLE.match(stripped):
+            flush()
+            sec = Section("title", stripped)
+            sec.lines.append(stripped)
+            sections.append(sec)
+            continue
+
+        if RE_LOG.match(stripped):
+            # Log lines stand alone -- one section per line.
+            flush()
+            m = RE_LOG.match(stripped)
+            sec = Section("log", stripped)
+            sec.lines.append(stripped)
+            try:
+                sec.date = _dt.date.fromisoformat(m.group(1))
+            except ValueError:
+                errors.append(f"line {i}: bad date in **Last Updated:** -> {stripped!r}")
+            sections.append(sec)
+            continue
+
+        if RE_BREADCRUMB.match(stripped):
+            flush()
+            sec = Section("breadcrumb", stripped)
+            sec.lines.append(stripped)
+            sections.append(sec)
+            continue
+
+        if RE_SEP.match(stripped):
+            flush()
+            sec = Section("sep", stripped)
+            sec.lines.append(stripped)
+            sections.append(sec)
+            continue
+
+        if stripped.startswith("## "):
+            flush()
+            m = RE_OPEN_DL.match(stripped)
+            if m:
+                cur = Section("open_dl", stripped)
+                cur.dl_num = int(m.group(1))
+                cur.title = m.group(2).strip()
+                cur.lines.append(stripped)
+                continue
+            m = RE_SHIPPED.match(stripped)
+            if m:
+                cur = Section("shipped", stripped)
+                cur.dl_num = int(m.group(1))
+                cur.title = m.group(2).strip()
+                try:
+                    cur.date = _dt.date.fromisoformat(m.group(3))
+                except ValueError:
+                    errors.append(f"line {i}: bad closed date -> {stripped!r}")
+                cur.lines.append(stripped)
+                continue
+            if RE_OPEN_OTHER.match(stripped):
+                cur = Section("open_other", stripped)
+                cur.lines.append(stripped)
+                continue
+            if RE_NEXT.match(stripped):
+                cur = Section("next", stripped)
+                cur.lines.append(stripped)
+                continue
+            if RE_RECENT.match(stripped):
+                cur = Section("recent", stripped)
+                cur.lines.append(stripped)
+                continue
+            m = RE_DATED.match(stripped)
+            if m:
+                cur = Section("dated", stripped)
+                try:
+                    cur.date = _dt.date.fromisoformat(m.group(1))
+                except ValueError:
+                    errors.append(f"line {i}: bad date in dated header -> {stripped!r}")
+                cur.title = m.group(2).strip()
+                cur.lines.append(stripped)
+                continue
+            errors.append(f"line {i}: unknown ## header -> {stripped!r}")
+            # Still accumulate so we don't lose data on a dry-run preview.
+            cur = Section("unknown", stripped)
+            cur.lines.append(stripped)
+            continue
+
+        # Non-header line: belongs to current section, or to a "preface"
+        # (blank/text before any section).
+        if cur is None:
+            # Treat leading content (blank lines, stray text) as preface.
+            if not sections or sections[-1].kind != "preface":
+                flush()
+                cur = Section("preface")
+            else:
+                cur = sections.pop()
+            cur.lines.append(stripped)
+            continue
+
+        cur.lines.append(stripped)
+
+    flush()
+    return sections, errors
+
+
+# ---- Transformations ----------------------------------------------------
+
+def trim_log(sections: list[Section]) -> int:
+    """Drop oldest log entries when count > LOG_THRESHOLD. Returns # dropped."""
+    log_idxs = [i for i, s in enumerate(sections) if s.kind == "log"]
+    if len(log_idxs) <= LOG_THRESHOLD:
+        return 0
+    # Newest first by file order (file convention: top is newest).
+    drop = log_idxs[LOG_KEEP:]
+    for i in sorted(drop, reverse=True):
+        del sections[i]
+    return len(drop)
+
+
+def demote_completed(
+    sections: list[Section], index: dict[int, str]
+) -> tuple[int, list[str]]:
+    """Convert ## OPEN: DL-NNN sections to ## SHIPPED one-liners when INDEX
+    says COMPLETED. Returns (count_demoted, warnings).
+    """
+    warnings: list[str] = []
+    demoted = 0
+    for i, sec in enumerate(sections):
+        if sec.kind != "open_dl":
+            continue
+        assert sec.dl_num is not None
+        status = index.get(sec.dl_num)
+        if status is None:
+            warnings.append(
+                f"DL-{sec.dl_num} referenced in current-status but not in INDEX.md"
+            )
+            continue
+        if not any(status.startswith(p) for p in COMPLETED_STATUS_PREFIXES):
+            # IMPLEMENTED/DRAFT/etc: keep full OPEN section.
+            continue
+        # Parse closed date from the status string ("COMPLETED — 2026-05-03").
+        m = RE_COMPLETED_DATE.search(status)
+        closed = m.group(1) if m else ""
+        title = sec.title
+        if closed:
+            new_header = f"## SHIPPED: DL-{sec.dl_num} — {title} (closed {closed})"
+        else:
+            new_header = f"## SHIPPED: DL-{sec.dl_num} — {title}"
+        new_sec = Section("shipped", new_header)
+        new_sec.dl_num = sec.dl_num
+        new_sec.title = title
+        try:
+            new_sec.date = _dt.date.fromisoformat(closed) if closed else None
+        except ValueError:
+            new_sec.date = None
+        new_sec.lines = [new_header]
+        sections[i] = new_sec
+        demoted += 1
+    return demoted, warnings
+
+
+def trim_recent(sections: list[Section], today: _dt.date) -> int:
+    """Drop bullets in '## Recent (last 7 days)' older than RECENT_WINDOW_DAYS.
+
+    Returns total bullets dropped across all Recent sections.
+    """
+    dropped = 0
+    cutoff = today - _dt.timedelta(days=RECENT_WINDOW_DAYS)
+    for sec in sections:
+        if sec.kind != "recent":
+            continue
+        new_lines: list[str] = []
+        for ln in sec.lines:
+            m = RE_RECENT_BULLET_DATE.match(ln)
+            if m:
+                try:
+                    d = _dt.date.fromisoformat(m.group(1))
+                except ValueError:
+                    new_lines.append(ln)
+                    continue
+                if d < cutoff:
+                    dropped += 1
+                    continue
+            new_lines.append(ln)
+        sec.lines = new_lines
+    return dropped
+
+
+def collect_archivable(
+    sections: list[Section], today: _dt.date
+) -> list[int]:
+    """Return indices of sections eligible to move to archive.
+
+    Eligibility: SHIPPED rows or DATED blocks with date older than
+    ARCHIVE_AGE_DAYS.
+    """
+    cutoff = today - _dt.timedelta(days=ARCHIVE_AGE_DAYS)
+    out: list[int] = []
+    for i, sec in enumerate(sections):
+        if sec.kind in ("shipped", "dated") and sec.date and sec.date < cutoff:
+            out.append(i)
+    return out
+
+
+def render(sections: list[Section]) -> str:
+    """Render sections back to markdown text. Strips trailing-blank-line runs
+    inside sections but preserves a single trailing blank between sections.
+    """
+    out: list[str] = []
+    for sec in sections:
+        lines = list(sec.lines)
+        # Trim trailing blanks within a section (we re-add one between sections).
+        while lines and lines[-1] == "":
+            lines.pop()
+        out.extend(lines)
+        out.append("")  # blank line between sections
+    # Collapse trailing blanks at file end to exactly one newline.
+    while out and out[-1] == "":
+        out.pop()
+    return "\n".join(out) + "\n"
+
+
+def line_count(text: str) -> int:
+    return text.count("\n") + (0 if text.endswith("\n") else 1)
+
+
+def update_breadcrumb(
+    sections: list[Section], today: _dt.date, archived_count: int
+) -> None:
+    """Replace any existing breadcrumb section with a fresh one. Always
+    appended to the end so it's the last visible line.
+    """
+    sections[:] = [s for s in sections if s.kind != "breadcrumb"]
+    line = (
+        f"> Older entries archived to `current-status-archive.md` "
+        f"(last pruned {today.isoformat()}, {archived_count} entries)."
+    )
+    bc = Section("breadcrumb", line)
+    bc.lines = [line]
+    sections.append(bc)
+
+
+# ---- Archive write ------------------------------------------------------
+
+def append_archive(archive_path: Path, archived_sections: list[Section], today: _dt.date) -> None:
+    if not archived_sections:
+        return
+    body_lines = [f"## Pruned {today.isoformat()} ({len(archived_sections)} entries)", ""]
+    for sec in archived_sections:
+        body_lines.extend(sec.lines)
+        body_lines.append("")
+    new_section = "\n".join(body_lines).rstrip() + "\n\n"
+
+    if archive_path.exists():
+        existing = archive_path.read_text(encoding="utf-8")
+        archive_path.write_text(new_section + existing, encoding="utf-8")
+    else:
+        header = (
+            "# Current Status — Archived Entries\n\n"
+            "Auto-pruned from `current-status.md` by `.claude/hooks/prune-current-status.py`.\n\n"
+        )
+        archive_path.write_text(header + new_section, encoding="utf-8")
+
+
+# ---- Run-counter + lock -------------------------------------------------
+
+def get_run_counter(state_dir: Path) -> int:
+    p = state_dir / "prune-runs.json"
+    if not p.exists():
+        return 0
+    try:
+        return int(json.loads(p.read_text(encoding="utf-8")).get("runs", 0))
+    except (ValueError, OSError, json.JSONDecodeError):
+        return 0
+
+
+def bump_run_counter(state_dir: Path) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    p = state_dir / "prune-runs.json"
+    n = get_run_counter(state_dir) + 1
+    p.write_text(json.dumps({"runs": n}), encoding="utf-8")
+
+
+def acquire_lock(lock_path: Path) -> bool:
+    """Return True if we hold the lock. Stale locks (>LOCK_TTL_SECONDS)
+    are stolen.
+    """
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        if lock_path.exists():
+            age = time.time() - lock_path.stat().st_mtime
+            if age < LOCK_TTL_SECONDS:
+                return False
+            # stale -- steal it
+            lock_path.unlink()
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        os.write(fd, str(os.getpid()).encode())
+        os.close(fd)
+        return True
+    except FileExistsError:
+        return False
+    except OSError:
+        return False
+
+
+def release_lock(lock_path: Path) -> None:
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
+
+
+# ---- Atomic write -------------------------------------------------------
+
+def atomic_write(path: Path, text: str) -> None:
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---- Main ---------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    cli_dry_run = "--dry-run" in argv
+
     here = Path(__file__).resolve()
     root = find_repo_root(here)
     if root is None:
         return 0
-    status = root / ".agent" / "current-status.md"
-    if not status.exists():
+    status_path = root / ".agent" / "current-status.md"
+    archive_path = root / ".agent" / "current-status-archive.md"
+    index_path = root / ".agent" / "design-logs" / "INDEX.md"
+    state_dir = root / ".claude" / "state"
+    lock_path = root / ".agent" / ".prune.lock"
+
+    if not status_path.exists():
         return 0
 
-    text = status.read_text(encoding="utf-8")
-    lines = text.splitlines(keepends=False)
+    if not acquire_lock(lock_path):
+        return 0  # another session pruning; skip silently
 
-    # Find separator line index (first standalone '---' after the title).
-    sep_idx = None
-    for i, ln in enumerate(lines):
-        if ln.strip() == "---" and i > 0:
-            sep_idx = i
-            break
+    try:
+        text = status_path.read_text(encoding="utf-8")
+        sections, parse_errors = parse(text)
+        if parse_errors:
+            for e in parse_errors:
+                warn(e)
+            warn("parse errors found, skipping run (no writes).")
+            return 0
 
-    header_lines = lines[:sep_idx] if sep_idx is not None else lines[:]
-    body_lines = lines[sep_idx:] if sep_idx is not None else []
+        index = load_index(index_path)
+        today = _dt.date.today()
 
-    # Collect entry line indices within header.
-    entry_idxs = [i for i, ln in enumerate(header_lines) if ln.startswith("**Last Updated:**")]
-    if len(entry_idxs) <= THRESHOLD:
-        return 0  # nothing to do
+        # Phase A: in-place transforms (always run; surfaced via dry-run preview).
+        log_dropped = trim_log(sections)
+        demoted, dl_warnings = demote_completed(sections, index)
+        for w in dl_warnings:
+            warn(w)
+        recent_dropped = trim_recent(sections, today)
 
-    # Newest entries are at the top of the file (file convention).
-    keep_idxs = set(entry_idxs[:KEEP])
-    archive_idxs = [i for i in entry_idxs if i not in keep_idxs]
+        # Phase B: archive overflow only when over LINE_CAP.
+        rendered = render(sections)
+        archived_sections: list[Section] = []
+        if line_count(rendered) > LINE_CAP:
+            arch_idxs = collect_archivable(sections, today)
+            archived_sections = [sections[i] for i in arch_idxs]
+            for i in sorted(arch_idxs, reverse=True):
+                del sections[i]
 
-    archived_lines = [header_lines[i] for i in archive_idxs]
-    new_header = [ln for i, ln in enumerate(header_lines) if i not in set(archive_idxs)]
+        # Phase C: breadcrumb. Only refresh if anything was archived this run
+        # OR an existing breadcrumb is present (idempotent).
+        had_breadcrumb = any(s.kind == "breadcrumb" for s in sections)
+        if archived_sections or had_breadcrumb:
+            # Total archived count: best-effort -- this run's count.
+            update_breadcrumb(sections, today, len(archived_sections))
 
-    # Rewrite current-status.md (header + separator + body).
-    out = "\n".join(new_header).rstrip() + "\n"
-    if body_lines:
-        out += "\n" + "\n".join(body_lines).rstrip() + "\n"
-    status.write_text(out, encoding="utf-8")
+        new_text = render(sections)
 
-    # Append-archive (newest-first within section, sections newest at top).
-    archive = root / ".agent" / "current-status-archive.md"
-    today = _dt.date.today().isoformat()
-    section = [f"## Pruned {today} ({len(archived_lines)} entries)", ""]
-    section.extend(archived_lines)
-    section.append("")
-    new_section = "\n".join(section) + "\n"
+        # No-op detection.
+        no_op = (new_text == text and not archived_sections)
+        if no_op:
+            return 0
 
-    if archive.exists():
-        existing = archive.read_text(encoding="utf-8")
-        archive.write_text(new_section + existing, encoding="utf-8")
-    else:
-        archive.write_text(
-            "# Current Status — Archived Entries\n\n"
-            "Auto-pruned from `current-status.md` by `.claude/hooks/prune-current-status.py`.\n\n"
-            + new_section,
-            encoding="utf-8",
+        # Decide dry-run vs wet.
+        run_n = get_run_counter(state_dir)
+        forced_dry = run_n < DRY_RUN_FIRST_N
+        is_dry = cli_dry_run or forced_dry
+
+        if is_dry:
+            why = "--dry-run" if cli_dry_run else f"forced (run {run_n + 1}/{DRY_RUN_FIRST_N})"
+            warn(f"DRY RUN ({why}): would mutate current-status.md")
+            warn(
+                f"  log entries dropped: {log_dropped}; "
+                f"OPEN sections demoted to SHIPPED: {demoted}; "
+                f"Recent bullets dropped: {recent_dropped}; "
+                f"sections archived: {len(archived_sections)}; "
+                f"projected line count: {line_count(new_text)}"
+            )
+            if not cli_dry_run:
+                bump_run_counter(state_dir)
+            return 0
+
+        # Wet run.
+        atomic_write(status_path, new_text)
+        if archived_sections:
+            append_archive(archive_path, archived_sections, today)
+        bump_run_counter(state_dir)
+        warn(
+            f"pruned: log -{log_dropped}, demoted {demoted}, "
+            f"recent -{recent_dropped}, archived {len(archived_sections)} "
+            f"({line_count(text)} -> {line_count(new_text)} lines)"
         )
+        return 0
 
-    sys.stderr.write(
-        f"[prune-current-status] archived {len(archived_lines)} entries "
-        f"(kept newest {KEEP})\n"
-    )
-    return 0
+    finally:
+        release_lock(lock_path)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/.gitignore
+++ b/.gitignore
@@ -103,5 +103,8 @@ docs/Samples/
 # Wrangler dryrun artifacts
 api/.dryrun-cors-preview/
 
+# Per-clone runtime state for hooks (e.g. prune-current-status run counter)
+.claude/state/
+
 # Added by ggshield
 .cache_ggshield


### PR DESCRIPTION
## Summary

- Replaces the SessionStart pruner that only counted **Last Updated:** lines (no-op for weeks).
- New version parses a typed grammar (TITLE / LOG / OPEN / SHIPPED / NEXT / RECENT / DATED / SEP), cross-references each \`## OPEN: DL-NNN\` against \`design-logs/INDEX.md\`, and demotes COMPLETED DLs to one-line SHIPPED breadcrumbs.
- Adds 7-day decay on Recent bullets, 14-day archive of stale SHIPPED+dated blocks (only when over 250 lines), atomic temp-write + lock, and counter-gated dry-run for the first 2 SessionStart firings.
- Bails loudly on unknown section headers — no silent corruption.

## Test plan

- [x] Dry-run on live file: 2 demotions (DL-400 + DL-395), no archive trigger (under 250 lines), parser clean.
- [x] Wet-run: 148 → 128 lines; diff confirms full OPEN blocks for DL-400/DL-395 collapsed to one-line SHIPPED rows; DL-404/DL-401/DL-365 + W02 untouched.
- [x] Pre-commit hooks pass (PII guard, ggshield, ratchet, entropy, workflow-export gate).
- [ ] Round-trip idempotency (run hook again immediately → no-op).
- [ ] Unknown-section bail test (inject \`## RANDOM:\` → stderr warn, no writes, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)